### PR TITLE
Fix redirection error on UI

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -22,7 +22,8 @@ rendered_md = requests.request("POST", url, json={"text": text}, headers=headers
 rendered_md = rendered_md \
     .replace(">\n<", "><") \
     .replace("/div>\n", "/div>") \
-    .replace("\n", "<br>")
+    .replace("\n", "<br>") \
+    .replace("\"", "")
 
 
 @app.get("/rendered_readme")


### PR DESCRIPTION
`README.md` have been mistakenly redirect to another location causing the error 
Fixed by removing `"` from the html since the webserver will automatically add double quote and add escaped character to the original double quote

Solves #13